### PR TITLE
parameter evaluation bug fix

### DIFF
--- a/kwikapi/api.py
+++ b/kwikapi/api.py
@@ -413,6 +413,8 @@ class BaseRequestHandler(object):
 
         for key, val in param_vals.items():
             try:
+                if params.get(key, {}).get('type', "") == type(val):
+                    continue
                 param_vals[key] = ast.literal_eval(val)
             except: # FIXME: bald except!
                 param_vals[key] = val


### PR DESCRIPTION
We were sending "2e4" as a string to kwikapi, but it was converting it to float to 20000.0
Fixed it by doing literal eval of the parameter only if the type of the parameter is different than that being defined in the function signature. 