### PR TITLE
fix for request.log exceptions

### DIFF
--- a/kwikapi/api.py
+++ b/kwikapi/api.py
@@ -398,6 +398,8 @@ class BaseRequestHandler(object):
                 function=fn_name,
                 apiid=self.api._id)
 
+        request.log = request.log or DUMMY_LOG
+
         query_string = urlp.query
 
         request.fn_name = fn_name


### PR DESCRIPTION
- When a user is not passing a log BaseRequestHandler we are using Dummy object by default but later on in `_resolve_call_info` we are using bind function from log to bind some values to log
- If user did not provide a log then it would be dummy object bind function which will return Nonetype
- This Nonetype object is stored in `request.log` which is being used in handle request to log something
- as request.log is None it is throwing following errors
```
NoneType object has no attribute 'exception'
NoneType object has no attribute 'info'
```