### PR TITLE
update README.md and deeputils latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ deploy:
   - LICENSE
   - kwikapi/api.py
   - kwikapi/__init__.py
-  name: kwikapi-0.5.12
-  tag_name: 0.5.12
+  name: kwikapi-0.5.13
+  tag_name: 0.5.13
   true:
     repo: deep-compute/kwikapi
 - provider: pypi

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Here is an example of how to use `KwikAPI` to expose `Calc` as a service. We wil
 > To use KwikAPI with tornado install `sudo pip3 install kwikapi[tornado]`
 
 ```python
+
+# `calc.py` - A simple calculator as a kwikapi service
+
 import tornado.ioloop
 import tornado.web
 
@@ -49,6 +52,11 @@ if __name__ == "__main__":
     app = make_app()
     app.listen(8888)
     tornado.ioloop.IOLoop.current().start()
+```
+
+#### Run Command
+```
+$ python calc.py run
 ```
 
 Making an API request

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "0.5.12"
+version = "0.5.13"
 setup(
     name="kwikapi",
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="contact@deepcompute.com",
     install_requires=[
         "msgpack-python==0.5.1",
-        "deeputil==0.2.7",
+        "deeputil==0.2.9",
         "numpy==1.15.1",
         "future==0.16.0",
         "requests>=2.18.4",


### PR DESCRIPTION
- Add run command in `README.md` for kwikapi[tornado] example
- Update `deeputil to 0.2.9` to avoid installing `six` package explicitly.
    Ref: https://github.com/deep-compute/deeputil/releases/tag/0.2.8